### PR TITLE
Implement AI query scheduler with FastAPI backend and Streamlit frontend

### DIFF
--- a/.openhands/TASKS.md
+++ b/.openhands/TASKS.md
@@ -1,0 +1,27 @@
+# Task List
+
+1. ✅ Set up project structure
+
+2. ✅ Install backend dependencies
+
+3. ✅ Install frontend dependencies
+
+4. ✅ Implement backend configuration and settings
+
+5. ✅ Implement AI query function
+
+6. ✅ Implement scheduler
+
+7. ✅ Implement backend API for result display
+
+8. ✅ Implement Streamlit frontend for settings
+
+9. ✅ Implement Streamlit frontend for result display
+
+10. ✅ Add error handling and edge cases
+
+11. 🔄 Test the application
+
+12. ⏳ Run the applications
+
+

--- a/backend/backend.log
+++ b/backend/backend.log
@@ -1,0 +1,26 @@
+/workspace/spec-kit-testproject/backend/main.py:112: DeprecationWarning: 
+        on_event is deprecated, use lifespan event handlers instead.
+
+        Read more about it in the
+        [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+        
+  @app.on_event("startup")
+/workspace/spec-kit-testproject/backend/main.py:129: DeprecationWarning: 
+        on_event is deprecated, use lifespan event handlers instead.
+
+        Read more about it in the
+        [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
+        
+  @app.on_event("shutdown")
+INFO:     Started server process [1941]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://0.0.0.0:50214 (Press CTRL+C to quit)
+/workspace/spec-kit-testproject/backend/main.py:72: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
+  json.dump(settings.dict(), f, indent=4)
+INFO:     127.0.0.1:59410 - "POST /settings HTTP/1.1" 200 OK
+INFO:     127.0.0.1:59414 - "GET /settings HTTP/1.1" 200 OK
+INFO:     127.0.0.1:59424 - "GET /result HTTP/1.1" 200 OK
+INFO:     127.0.0.1:56366 - "GET /settings HTTP/1.1" 200 OK
+INFO:     127.0.0.1:56372 - "GET /result HTTP/1.1" 200 OK
+INFO:     127.0.0.1:56376 - "POST /query HTTP/1.1" 200 OK

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,136 @@
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+import json
+import os
+from openai import OpenAI
+from datetime import datetime
+import time
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+app = FastAPI()
+
+SETTINGS_FILE = "/workspace/spec-kit-testproject/backend/settings.json"
+RESULTS_FILE = "/workspace/spec-kit-testproject/backend/results.json"
+
+class Settings(BaseModel):
+    prompt: str
+    execution_time: str  # e.g., "09:00"
+    api_key: str
+
+def query_ai():
+    if not os.path.exists(SETTINGS_FILE):
+        with open(RESULTS_FILE, 'w') as f:
+            json.dump({"error": "No settings found"}, f, indent=4)
+        return {"error": "No settings found"}
+
+    try:
+        with open(SETTINGS_FILE, 'r') as f:
+            settings = json.load(f)
+    except Exception as e:
+        error_msg = str(e)
+        with open(RESULTS_FILE, 'w') as f:
+            json.dump({"error": error_msg}, f, indent=4)
+        return {"error": error_msg}
+
+    client = OpenAI(
+        api_key=settings['api_key'],
+        base_url="https://openrouter.ai/api/v1"
+    )
+
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            response = client.chat.completions.create(
+                model="openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": settings['prompt']}]
+            )
+            result = {
+                "timestamp": datetime.now().isoformat(),
+                "prompt": settings['prompt'],
+                "response": response.choices[0].message.content
+            }
+            try:
+                with open(RESULTS_FILE, 'w') as f:
+                    json.dump(result, f, indent=4)
+            except Exception as save_e:
+                return {"error": f"Query succeeded but save failed: {str(save_e)}"}
+            return result
+        except Exception as e:
+            if attempt == max_retries - 1:
+                error_msg = f"Failed after {max_retries} attempts: {str(e)}"
+                with open(RESULTS_FILE, 'w') as f:
+                    json.dump({"error": error_msg}, f, indent=4)
+                return {"error": error_msg}
+            time.sleep(2 ** attempt)  # Exponential backoff
+
+@app.post("/settings")
+def save_settings(settings: Settings):
+    try:
+        with open(SETTINGS_FILE, 'w') as f:
+            json.dump(settings.dict(), f, indent=4)
+        # Update scheduler if needed
+        scheduler = getattr(app.state, 'scheduler', None)
+        if scheduler:
+            scheduler.remove_all_jobs()
+            hour, minute = map(int, settings.execution_time.split(':'))
+            scheduler.add_job(
+                query_ai,
+                CronTrigger(hour=hour, minute=minute),
+                id='daily_query'
+            )
+        return {"status": "saved"}
+    except Exception as e:
+        return {"error": str(e)}
+
+@app.get("/settings")
+def get_settings():
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            return {"error": str(e)}
+    return {"error": "No settings found"}
+
+@app.get("/result")
+def get_result():
+    if os.path.exists(RESULTS_FILE):
+        try:
+            with open(RESULTS_FILE, 'r') as f:
+                return json.load(f)
+        except Exception as e:
+            return {"error": str(e)}
+    return {"error": "No result found"}
+
+@app.post("/query")
+def trigger_query():
+    result = query_ai()
+    return result
+
+@app.on_event("startup")
+def startup_event():
+    app.state.scheduler = BackgroundScheduler()
+    if os.path.exists(SETTINGS_FILE):
+        try:
+            with open(SETTINGS_FILE, 'r') as f:
+                settings = json.load(f)
+            hour, minute = map(int, settings['execution_time'].split(':'))
+            app.state.scheduler.add_job(
+                query_ai,
+                CronTrigger(hour=hour, minute=minute),
+                id='daily_query'
+            )
+        except Exception as e:
+            print(f"Failed to schedule: {e}")
+    app.state.scheduler.start()
+
+@app.on_event("shutdown")
+def shutdown_event():
+    if hasattr(app.state, 'scheduler'):
+        app.state.scheduler.shutdown()
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=50214)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+apscheduler
+openai
+pydantic

--- a/backend/results.json
+++ b/backend/results.json
@@ -1,0 +1,3 @@
+{
+    "error": "Failed after 3 attempts: Error code: 401 - {'error': {'message': 'No auth credentials found', 'code': 401}}"
+}

--- a/backend/settings.json
+++ b/backend/settings.json
@@ -1,0 +1,5 @@
+{
+    "prompt": "What is the weather today?",
+    "execution_time": "09:00",
+    "api_key": "dummy_key"
+}

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,0 +1,85 @@
+
+
+import streamlit as st
+import requests
+import json
+
+BACKEND_URL = "http://localhost:50214"
+
+def get_settings():
+    try:
+        response = requests.get(f"{BACKEND_URL}/settings")
+        return response.json()
+    except Exception as e:
+        st.error(f"Error fetching settings: {e}")
+        return None
+
+def save_settings(settings):
+    try:
+        response = requests.post(f"{BACKEND_URL}/settings", json=settings)
+        return response.json()
+    except Exception as e:
+        st.error(f"Error saving settings: {e}")
+        return None
+
+def get_result():
+    try:
+        response = requests.get(f"{BACKEND_URL}/result")
+        return response.json()
+    except Exception as e:
+        st.error(f"Error fetching result: {e}")
+        return None
+
+tab1, tab2 = st.tabs(["Settings", "Results"])
+
+with tab1:
+    st.subheader("AI Query Scheduler Settings")
+    settings = get_settings()
+
+    if settings and "error" not in settings:
+        prompt = st.text_area("Prompt", value=settings.get("prompt", ""), height=200)
+        execution_time = st.text_input("Execution Time (HH:MM)", value=settings.get("execution_time", "09:00"))
+        api_key = st.text_input("Open Router API Key", value=settings.get("api_key", ""), type="password")
+    else:
+        prompt = st.text_area("Prompt", height=200)
+        execution_time = st.text_input("Execution Time (HH:MM)", "09:00")
+        api_key = st.text_input("Open Router API Key", type="password")
+
+    if st.button("Save Settings"):
+        new_settings = {
+            "prompt": prompt,
+            "execution_time": execution_time,
+            "api_key": api_key
+        }
+        result = save_settings(new_settings)
+        if result and "status" in result:
+            st.success("Settings saved successfully!")
+            st.rerun()
+        else:
+            st.error("Failed to save settings.")
+
+with tab2:
+    st.subheader("Latest AI Result")
+    result = get_result()
+    if result and "error" not in result:
+        st.write("**Timestamp:**", result.get("timestamp", "N/A"))
+        st.write("**Prompt:**", result.get("prompt", "N/A"))
+        st.markdown("**Response:**")
+        st.write(result.get("response", "N/A"))
+    elif result:
+        st.error(result.get("error", "Unknown error"))
+    else:
+        st.warning("No result available. Please set up settings and wait for the next scheduled run or trigger manually.")
+
+if st.button("Trigger Query Now"):
+    try:
+        response = requests.post(f"{BACKEND_URL}/query")
+        query_result = response.json()
+        if "error" not in query_result:
+            st.success("Query triggered successfully!")
+            st.rerun()
+        else:
+            st.error(f"Query failed: {query_result['error']}")
+    except Exception as e:
+        st.error(f"Error triggering query: {e}")
+

--- a/frontend/frontend.log
+++ b/frontend/frontend.log
@@ -1,0 +1,8 @@
+
+Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.
+
+
+  You can now view your Streamlit app in your browser.
+
+  URL: http://0.0.0.0:55930
+

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,0 +1,3 @@
+
+streamlit
+requests


### PR DESCRIPTION

This PR implements the specified feature from spec-kit-testproject/specs/001-web-n-n:

- Backend with FastAPI: Handles settings (prompt, execution time, Open Router API key) in JSON, AI query to Open Router using openai client with retries, saves results to JSON, and schedules daily runs with APScheduler.
- Frontend with Streamlit: Tabs for settings (edit and save via API) and results (display latest AI response or errors), plus manual trigger button.
- Error handling: For missing settings, API failures (3 retries with backoff), save errors.
- Runs on ports 50214 (backend) and 55930 (frontend), accessible from 0.0.0.0.

Tested manually: Settings save, manual query (fails without real API key), results display.

Co-authored-by: openhands <openhands@all-hands.dev>
