### PR TITLE
Fix backend import error by adding cryptography dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]
 apscheduler
 openai
 pydantic
+cryptography


### PR DESCRIPTION
This PR adds the 'cryptography' package to the backend/requirements.txt file to resolve the ModuleNotFoundError for 'cryptography.fernet' when starting the backend service via docker-compose.

The error occurred because the cryptography library was imported in main.py but not listed in the dependencies. With this change, the Docker build should install it correctly, allowing the backend to start without issues.

Co-authored-by: openhands <openhands@all-hands.dev>